### PR TITLE
Handle errors connecting to the ONVIF Camera eg password error

### DIFF
--- a/motion-onvif-events.js
+++ b/motion-onvif-events.js
@@ -64,7 +64,13 @@ class Monitor {
 
   static createCamera(conf) {
     return new Promise(resolve => {
-      const cam = new Cam(conf, () => resolve(cam));
+      const cam = new Cam(conf, (err) => {
+        if (err) {
+          console.log('Error connecting to ONVIF Camera ' + err);
+          process.exit();
+        }
+        resolve(cam)
+      });
     })
   }
 


### PR DESCRIPTION
I work on the underlying node onvif library that you use.

We had a Issue Report for someone using motion-onvif-events and getting an error about creating a Pull Point Subscription.

I think the root cause is that your utility did not handle errors back from the onvif library, eg if a username/password is incorrect.

So I've added that in for you in this PR.

Thanks
Roger Hardiman